### PR TITLE
Load default config when no TOML is specified.

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -63,6 +63,10 @@ impl std::fmt::Display for ConfigError {
 impl std::error::Error for ConfigError {}
 
 impl Configuration {
+    pub fn load_defaults() -> Configuration {
+        Self::default()
+    }
+
     pub fn load(data: &[u8]) -> Result<Configuration, toml::de::Error> {
         toml::from_slice(data)
     }
@@ -104,7 +108,7 @@ impl Configuration {
     }
 }
 
-impl Default for Configuration {
+impl Configuration {
     fn default() -> Configuration {
         Configuration {
             log_level: None,
@@ -113,7 +117,10 @@ impl Default for Configuration {
                 announce_interval: 120,
                 bind_address: String::from("0.0.0.0:6969"),
             },
-            http: None,
+            http: Option::from(HTTPConfig {
+                bind_address: String::from("127.0.0.1:6969"),
+                access_tokens: Default::default()
+            }),
             db_path: None,
             cleanup_interval: None,
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,17 +61,23 @@ async fn main() {
                 .takes_value(true)
                 .short("-c")
                 .help("Configuration file to load.")
-                .required(true),
         );
 
     let matches = parser.get_matches();
-    let cfg_path = matches.value_of("config").unwrap();
 
-    let cfg = match Configuration::load_file(cfg_path) {
-        Ok(v) => std::sync::Arc::new(v),
-        Err(e) => {
-            eprintln!("udpt: failed to open configuration: {}", e);
-            return;
+    let cfg = match matches.value_of("config") {
+        Some(cfg_path) => {
+            match Configuration::load_file(cfg_path) {
+                Ok(v) => std::sync::Arc::new(v),
+                Err(e) => {
+                    eprintln!("udpt: failed to open configuration: {}", e);
+                    return;
+                }
+            }
+        },
+        None => {
+            eprintln!("No TOML supplied. Loading default configuration.");
+            std::sync::Arc::new(Configuration::load_defaults())
         }
     };
 


### PR DESCRIPTION
A configuration TOML shouldn't be required. A default configuration also makes it easier to debug the app.